### PR TITLE
feat: add TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ possible environment variables:<br>
 <b>FROM_DATE</b> - in format of 2019-01-01 (default: 2019-01-01) <br>
 <b>TO_DATE</b> - in format of 2019-01-01 (default: not passed => till latest) <br>
 <b>ACCOUNT_ID</b> - generate report only for a specific account id. mongo id string <br>
+
+
+## TLS
+
+Set as env variables; applicable to both scripts above.
+
+<b>TLS</b> — Enables or disables TLS/SSL for the connection — `"true"`/`"false"` (default: `"false"`)<br>
+<b>TLS_CA_FILE</b> — Location of a local .pem file that contains the root certificate chain from the Certificate Authority.<br>
+<b>TLS_CERT_FILE</b> — Location of a local TLS Certificate.<br>
+<b>TLS_CERT_KEY_FILE</b> — Location of a local .pem file that contains either the client's TLS/SSL certificate and key or only the client's TLS/SSL key when `TLS_CERT_FILE` is used to provide the certificate.<br>
+<b>TLS_CERT_KEY_FILE_PASSWORD</b> — Password to de-crypt the `TLS_CERT_KEY_FILE`.<br>

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -1,0 +1,20 @@
+//@ts-check
+
+const tls = process.env.TLS === 'true';
+const tlsCAFile = process.env.TLS_CA_FILE || undefined;
+const tlsCertificateFile = process.env.TLS_CERT_FILE || undefined;
+const tlsCertificateKeyFile = process.env.TLS_CERT_KEY_FILE || undefined;
+const tlsCertificateKeyFilePassword = process.env.TLS_CERT_KEY_FILE_PASSWORD || undefined;
+
+/**
+ * @type { import('mongodb').MongoClientOptions }
+ */
+const options = {
+  tls,
+  tlsCAFile,
+  tlsCertificateFile,
+  tlsCertificateKeyFile,
+  tlsCertificateKeyFilePassword,
+};
+
+exports.options = options;

--- a/lib/mongo-builds-list.js
+++ b/lib/mongo-builds-list.js
@@ -1,3 +1,4 @@
+//@ts-check
 'use strict';
 
 const MongoClient = require('mongodb').MongoClient;
@@ -8,6 +9,7 @@ const {table} = require('table');
 const { Parser } = require('json2csv');
 const fs = require('fs');
 const path = require('path');
+const { options } = require('./client-options');
 
 //TODO
 // 0. validate numbers are not good for hover
@@ -30,7 +32,7 @@ const main = async () => {
     // Connection url
     const url = process.env.MONGO_URI || 'mongodb://localhost';
     // Connect using MongoClient
-    const adminDb        = await MongoClient.connect(url);
+    const adminDb        = await MongoClient.connect(url, options);
     db = adminDb.db(process.env.API_DB || "local");
 
     try {

--- a/lib/mongo-builds-list.js
+++ b/lib/mongo-builds-list.js
@@ -91,8 +91,8 @@ const _getAllBuilds = async () => {
 
     const cursor    = col.find(
         {
-            "_id": { $gte: ObjectId(Math.floor((new Date(`${FROM_DATE}T00:00:00.000+0000`).getTime()) / 1000).toString(16) + "0000000000000000"), ...(TO_DATE && {$lte: ObjectId(Math.floor((new Date(`${TO_DATE}T00:00:00.000+0000`).getTime()) / 1000).toString(16) + "0000000000000000")}) }, ...(process.env.ACCOUNT_ID &&
-                { "account": ObjectId(process.env.ACCOUNT_ID) })
+            "_id": { $gte: new ObjectId(Math.floor((new Date(`${FROM_DATE}T00:00:00.000+0000`).getTime()) / 1000).toString(16) + "0000000000000000"), ...(TO_DATE && {$lte: new ObjectId(Math.floor((new Date(`${TO_DATE}T00:00:00.000+0000`).getTime()) / 1000).toString(16) + "0000000000000000")}) }, ...(process.env.ACCOUNT_ID &&
+                { "account": new ObjectId(process.env.ACCOUNT_ID) })
         },
         {
             _id: 1,
@@ -139,11 +139,11 @@ const _millisToMinutes = (millisec) => {
 
     var days = (millisec / (1000 * 60 * 60 * 24)).toFixed(1);
 
-    if (seconds < 60) {
+    if (+seconds < 60) {
         return seconds + " Sec";
-    } else if (minutes < 60) {
+    } else if (+minutes < 60) {
         return minutes + " Min";
-    } else if (hours < 24) {
+    } else if (+hours < 24) {
         return hours + " Hrs";
     } else {
         return days + " Days"
@@ -244,7 +244,7 @@ const exportDocs = async () => {
 
     _.forEach(buildsPerAccount, (accountBuilds, accountId) => {
         const title = `Summary for account: ${accountId}`;
-        const data = _calculateTable(accountBuilds, eventsPerAccount[accountId]);
+        const data = _calculateTable(accountBuilds);
         //_printTable(title, data);
         _extendCSV(title, data);
     });

--- a/lib/mongo-builds-summary.js
+++ b/lib/mongo-builds-summary.js
@@ -1,3 +1,4 @@
+//@ts-check
 'use strict';
 
 const MongoClient = require('mongodb').MongoClient;
@@ -8,6 +9,7 @@ const {table} = require('table');
 const { Parser } = require('json2csv');
 const fs = require('fs');
 const path = require('path');
+const { options } = require('./client-options');
 
 //TODO
 // 0. validate numbers are not good for hover
@@ -30,7 +32,7 @@ const main = async () => {
     // Connection url
     const url = process.env.MONGO_URI || 'mongodb://localhost';
     // Connect using MongoClient
-    const adminDb        = await MongoClient.connect(url);
+    const adminDb        = await MongoClient.connect(url, options);
     db = adminDb.db(process.env.API_DB || "local");
 
     try {

--- a/lib/mongo-builds-summary.js
+++ b/lib/mongo-builds-summary.js
@@ -57,7 +57,7 @@ const _getStatusCount = (builds) => {
     const totals = _.countBy(builds, (build) => {
         return build.status;
     });
-    return JSON.stringify(totals, 2, 4);
+    return JSON.stringify(totals, null, 4);
 };
 
 const _getOperationCount = (builds) => {
@@ -65,7 +65,7 @@ const _getOperationCount = (builds) => {
         return build.trigger;
     });
     delete totals.undefined;
-    return JSON.stringify(totals, 2, 4);
+    return JSON.stringify(totals, null, 4);
 };
 
 const _getTerminationCount = (builds) => {
@@ -73,7 +73,7 @@ const _getTerminationCount = (builds) => {
         return _.get(build, 'terminationRequest.0.cause');
     });
     delete totals.undefined;
-    return JSON.stringify(totals, 2, 4);
+    return JSON.stringify(totals, null, 4);
 };
 
 const _getRuntimeCount = (builds) => {
@@ -81,7 +81,7 @@ const _getRuntimeCount = (builds) => {
         return _.get(build, 'runtimeEnvironmentMetadata.name');
     });
     delete totals.undefined;
-    return JSON.stringify(totals, 2, 4);
+    return JSON.stringify(totals, null, 4);
 };
 
 const _getMaxParallelDelayedCount = (events) => {
@@ -134,7 +134,7 @@ const _getMaxParallelRunningCount = (events) => {
         }
     });
 
-    return `${maxRunning} ${process.env.PRINT_MAX_DELAYED_BUILDS ? JSON.stringify(_.map(maxBuildIds, id => id), 4, 2) : ''}`;
+    return `${maxRunning} ${process.env.PRINT_MAX_DELAYED_BUILDS ? JSON.stringify(_.map(maxBuildIds, id => id), null, 2) : ''}`;
 };
 
 const _getDelayedBuilds = (builds) => {
@@ -190,8 +190,8 @@ const _getAllBuilds = async () => {
 
     const cursor    = col.find(
         {
-            "_id": { $gte: ObjectId(Math.floor((new Date(`${FROM_DATE}T00:00:00.000+0000`).getTime()) / 1000).toString(16) + "0000000000000000"), ...(TO_DATE && {$lte: ObjectId(Math.floor((new Date(`${TO_DATE}T00:00:00.000+0000`).getTime()) / 1000).toString(16) + "0000000000000000")}) }, ...(process.env.ACCOUNT_ID &&
-                { "account": ObjectId(process.env.ACCOUNT_ID) })
+            "_id": { $gte: new ObjectId(Math.floor((new Date(`${FROM_DATE}T00:00:00.000+0000`).getTime()) / 1000).toString(16) + "0000000000000000"), ...(TO_DATE && {$lte: new ObjectId(Math.floor((new Date(`${TO_DATE}T00:00:00.000+0000`).getTime()) / 1000).toString(16) + "0000000000000000")}) }, ...(process.env.ACCOUNT_ID &&
+                { "account": new ObjectId(process.env.ACCOUNT_ID) })
         },
         {
             _id: 1,
@@ -271,11 +271,11 @@ const _millisToMinutes = (millisec) => {
 
     var days = (millisec / (1000 * 60 * 60 * 24)).toFixed(1);
 
-    if (seconds < 60) {
+    if (+seconds < 60) {
         return seconds + " Sec";
-    } else if (minutes < 60) {
+    } else if (+minutes < 60) {
         return minutes + " Min";
-    } else if (hours < 24) {
+    } else if (+hours < 24) {
         return hours + " Hrs";
     } else {
         return days + " Days"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,224 +1,288 @@
 {
   "name": "onprem-analytics",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "ajv": {
+  "packages": {
+    "": {
+      "name": "onprem-analytics",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "json2csv": "^4.5.4",
+        "lodash": "^4.17.4",
+        "mongodb": "^3.3.4",
+        "table": "^5.4.6"
+      }
+    },
+    "node_modules/ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-      "requires": {
+      "dependencies": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
     },
-    "ansi-regex": {
+    "node_modules/ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "ansi-styles": {
+    "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "requires": {
+      "dependencies": {
         "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "astral-regex": {
+    "node_modules/astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "bluebird": {
+    "node_modules/bluebird": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
       "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
     },
-    "bson": {
+    "node_modules/bson": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
-      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
+      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg==",
+      "deprecated": "Fixed a critical issue with BSON serialization documented in CVE-2019-2391, see https://bit.ly/2KcpXdo for more details",
+      "engines": {
+        "node": ">=0.6.19"
+      }
     },
-    "color-convert": {
+    "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "requires": {
+      "dependencies": {
         "color-name": "1.1.3"
       }
     },
-    "color-name": {
+    "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
-    "commander": {
+    "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
-    "emoji-regex": {
+    "node_modules/emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
-    "fast-deep-equal": {
+    "node_modules/fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
-    "fast-json-stable-stringify": {
+    "node_modules/fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
-    "is-fullwidth-code-point": {
+    "node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "json-schema-traverse": {
+    "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
-    "json2csv": {
+    "node_modules/json2csv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-4.5.4.tgz",
       "integrity": "sha512-YxBhY4Lmn8IvVZ36nqg5omxneLy9JlorkqW1j/EDCeqvmi+CQ4uM+wsvXlcIqvGDewIPXMC/O/oF8DX9EH5aoA==",
-      "requires": {
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
         "commander": "^2.15.1",
         "jsonparse": "^1.3.1",
         "lodash.get": "^4.4.2"
+      },
+      "bin": {
+        "json2csv": "bin/json2csv.js"
       }
     },
-    "jsonparse": {
+    "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "engines": [
+        "node >= 0.2.0"
+      ]
     },
-    "lodash": {
+    "node_modules/lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash.get": {
+    "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
-    "memory-pager": {
+    "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "optional": true
     },
-    "mongodb": {
+    "node_modules/mongodb": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.4.tgz",
       "integrity": "sha512-6fmHu3FJTpeZxacJcfjUGIP3BSteG0l2cxLkSrf1nnnS1OrlnVGiP9P/wAC4aB6dM6H4vQ2io8YDjkuPkje7AA==",
-      "requires": {
+      "dependencies": {
         "bson": "^1.1.1",
         "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2",
+        "safe-buffer": "^5.1.2"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "optionalDependencies": {
         "saslprep": "^1.0.0"
       }
     },
-    "punycode": {
+    "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "require_optional": {
+    "node_modules/require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "requires": {
+      "dependencies": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"
       }
     },
-    "resolve-from": {
+    "node_modules/resolve-from": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "safe-buffer": {
+    "node_modules/safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
       "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
-    "saslprep": {
+    "node_modules/saslprep": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
       "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
-    "semver": {
+    "node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
-    "slice-ansi": {
+    "node_modules/slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
       "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-      "requires": {
+      "dependencies": {
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
-    "sparse-bitfield": {
+    "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "memory-pager": "^1.0.2"
       }
     },
-    "string-width": {
+    "node_modules/string-width": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "requires": {
+      "dependencies": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
-    "strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "requires": {
+      "dependencies": {
         "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
-    "table": {
+    "node_modules/table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
       "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-      "requires": {
+      "dependencies": {
         "ajv": "^6.10.2",
         "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
-    "uri-js": {
+    "node_modules/uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "requires": {
+      "dependencies": {
         "punycode": "^2.1.0"
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,36 @@
         "bluebird": "^3.5.0",
         "json2csv": "^4.5.4",
         "lodash": "^4.17.4",
-        "mongodb": "^3.3.4",
+        "mongodb": "^5.8.1",
         "table": "^5.4.6"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
+      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/ajv": {
@@ -60,12 +88,11 @@
       "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
     },
     "node_modules/bson": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
-      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg==",
-      "deprecated": "Fixed a critical issue with BSON serialization documented in CVE-2019-2391, see https://bit.ly/2KcpXdo for more details",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
+      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
       "engines": {
-        "node": ">=0.6.19"
+        "node": ">=14.20.1"
       }
     },
     "node_modules/color-convert": {
@@ -100,6 +127,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "node_modules/ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -153,19 +185,52 @@
       "optional": true
     },
     "node_modules/mongodb": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.4.tgz",
-      "integrity": "sha512-6fmHu3FJTpeZxacJcfjUGIP3BSteG0l2cxLkSrf1nnnS1OrlnVGiP9P/wAC4aB6dM6H4vQ2io8YDjkuPkje7AA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
+      "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
       "dependencies": {
-        "bson": "^1.1.1",
-        "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2"
+        "bson": "^5.4.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=14.20.1"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.0"
+        "@mongodb-js/saslprep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
       }
     },
     "node_modules/punycode": {
@@ -174,48 +239,6 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "dependencies": {
-        "resolve-from": "^2.0.0",
-        "semver": "^5.1.0"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-    },
-    "node_modules/saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/slice-ansi": {
@@ -231,10 +254,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "dependencies": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
@@ -278,12 +323,43 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,20 +45,24 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dependencies": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "engines": {
         "node": ">=6"
       }
@@ -119,9 +123,9 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -169,9 +173,9 @@
       ]
     },
     "node_modules/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bluebird": "^3.5.0",
     "json2csv": "^4.5.4",
     "lodash": "^4.17.4",
-    "mongodb": "^3.3.4",
+    "mongodb": "^5.8.1",
     "table": "^5.4.6"
   }
 }


### PR DESCRIPTION
This adds a TLS support by adding the following optional environment variables:

* TLS — Enables or disables TLS/SSL for the connection — `"true"`/`"false"` (default: `"false"`)
* TLS_CA_FILE — Location of a local .pem file that contains the root certificate chain from the Certificate Authority.
* TLS_CERT_FILE — Location of a local TLS Certificate.
* TLS_CERT_KEY_FILE — Location of a local .pem file that contains either the client's TLS/SSL certificate and key or only the client's TLS/SSL key when `TLS_CERT_FILE` is used to provide the certificate.
* TLS_CERT_KEY_FILE_PASSWORD — Password to de-crypt the `TLS_CERT_KEY_FILE`.